### PR TITLE
Changing order in Sys.init

### DIFF
--- a/12/Sys.jack
+++ b/12/Sys.jack
@@ -10,11 +10,11 @@ class Sys {
 
     /** Performs all the initializations required by the OS. */
     function void init() {
+        do Memory.init();
         do Math.init();
         do Output.init();
         do Screen.init();
         do Keyboard.init();
-        do Memory.init();
         do Main.main();
         do Sys.halt();
         return;


### PR DESCRIPTION
As "Math.init" is using "Array" which in turns use "Memory.init" so In "sys.init" memory should be called, and initialized first.